### PR TITLE
Changed SphinxSearchBundle->search() to match API

### DIFF
--- a/Resources/config/sphinxsearch.xml
+++ b/Resources/config/sphinxsearch.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="search.sphinxsearch.search" class="%search.sphinxsearch.search.class%">
-            <file>%kernel.root_dir%/../src/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
+            <file>%kernel.root_dir%/../vendor/bundles/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
             <argument>%search.sphinxsearch.searchd.host%</argument>
             <argument>%search.sphinxsearch.searchd.port%</argument>
             <argument>%search.sphinxsearch.searchd.socket%</argument>


### PR DESCRIPTION
I have changed the search function to match the intended SphinxAPI behavior.

Previously when you searched multiple indexes with:
    $indexes = array(
                'All_Items' => array(
                    'result_offset' => 0,
                    'result_limit'  => 1000
                        ),
                'All_Items_Delta' => array(
                    'result_offset' => 0,
                    'result_limit'  => 1000
                        )
                );

```
$result = $sphinxsearch->search($search_str,$indexes);
```

It executed SphinxAPI->query() once for each index and saved the results to a named array. This means advanced functionality like kill-lists do not work.

I have changed it so it now executes SphinxAPI->query() once with both indexes and my kill-list now works as intended which means I can have a delta index of updates and a full index but, not have results from the full index returned if that document exists in delta index (the delta being the latest version).

If someone wanted to execute a search on two different indexes independently I would expect they run SphinxSearchBundle->search() twice.

Anyhow fix my problem, not sure if you want to include it in the bundle.

Cheers for all your hard work, made it much easier for me to integrate Sphinx and Symfony2 thats for sure!
