### PR TITLE
Changed SphinxSearchBundle->search() to match API

### DIFF
--- a/Resources/config/sphinxsearch.xml
+++ b/Resources/config/sphinxsearch.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="search.sphinxsearch.search" class="%search.sphinxsearch.search.class%">
-            <file>%kernel.root_dir%/../src/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
+            <file>%kernel.root_dir%/../vendor/bundles/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
             <argument>%search.sphinxsearch.searchd.host%</argument>
             <argument>%search.sphinxsearch.searchd.port%</argument>
             <argument>%search.sphinxsearch.searchd.socket%</argument>

--- a/Resources/config/sphinxsearch.xml
+++ b/Resources/config/sphinxsearch.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="search.sphinxsearch.search" class="%search.sphinxsearch.search.class%">
-            <file>%kernel.root_dir%/../vendor/bundles/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
+            <file>%kernel.root_dir%/../vendor/chrisapl/search-sphinxsearchbundle/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
             <argument>%search.sphinxsearch.searchd.host%</argument>
             <argument>%search.sphinxsearch.searchd.port%</argument>
             <argument>%search.sphinxsearch.searchd.socket%</argument>

--- a/Services/Indexer/Indexer.php
+++ b/Services/Indexer/Indexer.php
@@ -2,7 +2,7 @@
 
 namespace Search\SphinxsearchBundle\Services\Indexer;
 
-use Assetic\Util\ProcessBuilder;
+use Symfony\Component\Process\ProcessBuilder;
 
 class Indexer
 {
@@ -65,6 +65,7 @@ class Indexer
 		if( is_array($indexes) ) {
 			foreach( $indexes as &$label ) {
 				if( isset($this->indexes[$label]) )
+			
 					$pb->add($this->indexes[$label]['index_name']);
 			}
 		} elseif( is_string($indexes) ) {

--- a/Services/Search/SearchTest.php
+++ b/Services/Search/SearchTest.php
@@ -1,0 +1,168 @@
+<?php
+
+//
+// $Id$
+//
+
+require ( "SphinxAPI.php" );
+
+//////////////////////
+// parse command line
+//////////////////////
+
+// for very old PHP versions, like at my home test server
+if ( is_array($argv) && !isset($_SERVER["argv"]) )
+        $_SERVER["argv"] = $argv;
+unset ( $_SERVER["argv"][0] );
+
+// build query
+if ( !is_array($_SERVER["argv"]) || empty($_SERVER["argv"]) )
+{
+        print ( "Usage: php -f test.php [OPTIONS] query words\n\n" );
+        print ( "Options are:\n" );
+        print ( "-h, --host <HOST>\tconnect to searchd at host HOST\n" );
+        print ( "-p, --port\t\tconnect to searchd at port PORT\n" );
+        print ( "-i, --index <IDX>\tsearch through index(es) specified by IDX\n" );
+        print ( "-s, --sortby <CLAUSE>\tsort matches by 'CLAUSE' in sort_extended mode\n" );
+        print ( "-S, --sortexpr <EXPR>\tsort matches by 'EXPR' DESC in sort_expr mode\n" );
+        print ( "-a, --any\t\tuse 'match any word' matching mode\n" );
+        print ( "-b, --boolean\t\tuse 'boolean query' matching mode\n" );
+        print ( "-e, --extended\t\tuse 'extended query' matching mode\n" );
+        print ( "-ph,--phrase\t\tuse 'exact phrase' matching mode\n" );
+        print ( "-f, --filter <ATTR>\tfilter by attribute 'ATTR' (default is 'group_id')\n" );
+        print ( "-fr,--filterrange <ATTR> <MIN> <MAX>\n\t\t\tadd specified range filter\n" );
+        print ( "-v, --value <VAL>\tadd VAL to allowed 'group_id' values list\n" );
+        print ( "-g, --groupby <EXPR>\tgroup matches by 'EXPR'\n" );
+        print ( "-gs,--groupsort <EXPR>\tsort groups by 'EXPR'\n" );
+        print ( "-d, --distinct <ATTR>\tcount distinct values of 'ATTR''\n" );
+        print ( "-l, --limit <COUNT>\tretrieve COUNT matches (default: 20)\n" );
+        print ( "--select <EXPRLIST>\tuse 'EXPRLIST' as select-list (default: *)\n" );
+        exit;
+}
+
+$args = array();
+foreach ( $_SERVER["argv"] as $arg )
+        $args[] = $arg;
+
+$cl = new SphinxClient ();
+
+$q = "";
+$sql = "";
+$mode = SPH_MATCH_ALL;
+$host = "localhost";
+$port = 9312;
+$index = "*";
+$groupby = "";
+$groupsort = "@group desc";
+$filter = "group_id";
+$filtervals = array();
+$distinct = "";
+$sortby = "";
+$sortexpr = "";
+$limit = 20;
+$ranker = SPH_RANK_PROXIMITY_BM25;
+$select = "";
+for ( $i=0; $i<count($args); $i++ )
+{
+        $arg = $args[$i];
+
+        if ( $arg=="-h" || $arg=="--host" )                             $host = $args[++$i];
+        else if ( $arg=="-p" || $arg=="--port" )                $port = (int)$args[++$i];
+        else if ( $arg=="-i" || $arg=="--index" )               $index = $args[++$i];
+        else if ( $arg=="-s" || $arg=="--sortby" )              { $sortby = $args[++$i]; $sortexpr = ""; }
+        else if ( $arg=="-S" || $arg=="--sortexpr" )    { $sortexpr = $args[++$i]; $sortby = ""; }
+        else if ( $arg=="-a" || $arg=="--any" )                 $mode = SPH_MATCH_ANY;
+        else if ( $arg=="-b" || $arg=="--boolean" )             $mode = SPH_MATCH_BOOLEAN;
+        else if ( $arg=="-e" || $arg=="--extended" )    $mode = SPH_MATCH_EXTENDED;
+        else if ( $arg=="-e2" )                                                 $mode = SPH_MATCH_EXTENDED2;
+        else if ( $arg=="-ph"|| $arg=="--phrase" )              $mode = SPH_MATCH_PHRASE;
+        else if ( $arg=="-f" || $arg=="--filter" )              $filter = $args[++$i];
+        else if ( $arg=="-v" || $arg=="--value" )               $filtervals[] = $args[++$i];
+        else if ( $arg=="-g" || $arg=="--groupby" )             $groupby = $args[++$i];
+        else if ( $arg=="-gs"|| $arg=="--groupsort" )   $groupsort = $args[++$i];
+        else if ( $arg=="-d" || $arg=="--distinct" )    $distinct = $args[++$i];
+        else if ( $arg=="-l" || $arg=="--limit" )               $limit = (int)$args[++$i];
+        else if ( $arg=="--select" )                                    $select = $args[++$i];
+        else if ( $arg=="-fr"|| $arg=="--filterrange" ) $cl->SetFilterRange ( $args[++$i], $args[++$i], $args[++$i] );
+        else if ( $arg=="-r" )
+        {
+                $arg = strtolower($args[++$i]);
+                if ( $arg=="bm25" )             $ranker = SPH_RANK_BM25;
+                if ( $arg=="none" )             $ranker = SPH_RANK_NONE;
+                if ( $arg=="wordcount" )$ranker = SPH_RANK_WORDCOUNT;
+                if ( $arg=="fieldmask" )$ranker = SPH_RANK_FIELDMASK;
+                if ( $arg=="sph04" )    $ranker = SPH_RANK_SPH04;
+        }
+        else
+                $q .= $args[$i] . " ";
+}
+
+////////////
+// do query
+////////////
+
+$cl->SetServer ( $host, $port );
+$cl->SetConnectTimeout ( 1 );
+$cl->SetArrayResult ( true );
+$cl->SetMatchMode ( $mode );
+if ( count($filtervals) )       $cl->SetFilter ( $filter, $filtervals );
+if ( $groupby )                         $cl->SetGroupBy ( $groupby, SPH_GROUPBY_ATTR, $groupsort );
+if ( $sortby )                          $cl->SetSortMode ( SPH_SORT_EXTENDED, $sortby );
+if ( $sortexpr )                        $cl->SetSortMode ( SPH_SORT_EXPR, $sortexpr );
+if ( $distinct )                        $cl->SetGroupDistinct ( $distinct );
+if ( $select )                          $cl->SetSelect ( $select );
+if ( $limit )                           $cl->SetLimits ( 0, $limit, ( $limit>1000 ) ? $limit : 1000 );
+$cl->SetRankingMode ( $ranker );
+$res = $cl->Query ( $q, $index );
+
+////////////////
+// print me out
+////////////////
+
+if ( $res===false )
+{
+        print "Query failed: " . $cl->GetLastError() . ".\n";
+
+} else
+{
+        if ( $cl->GetLastWarning() )
+                print "WARNING: " . $cl->GetLastWarning() . "\n\n";
+
+        print "Query '$q' retrieved $res[total] of $res[total_found] matches in $res[time] sec.\n";
+        print "Query stats:\n";
+        if ( is_array($res["words"]) )
+                foreach ( $res["words"] as $word => $info )
+                        print "    '$word' found $info[hits] times in $info[docs] documents\n";
+        print "\n";
+
+        if ( is_array($res["matches"]) )
+        {
+                $n = 1;
+                print "Matches:\n";
+                foreach ( $res["matches"] as $docinfo )
+                {
+                        print "$n. doc_id=$docinfo[id], weight=$docinfo[weight]";
+                        foreach ( $res["attrs"] as $attrname => $attrtype )
+                        {
+                                $value = $docinfo["attrs"][$attrname];
+                                if ( $attrtype==SPH_ATTR_MULTI || $attrtype==SPH_ATTR_MULTI64 )
+                                {
+                                        $value = "(" . join ( ",", $value ) .")";
+                                } else
+                                {
+                                        if ( $attrtype==SPH_ATTR_TIMESTAMP )
+                                                $value = date ( "Y-m-d H:i:s", $value );
+                                }
+                                print ", $attrname=$value";
+                        }
+                        print "\n";
+                        $n++;
+                }
+        }
+}
+
+//
+// $Id$
+//
+
+?>

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -132,7 +132,7 @@ class Sphinxsearch
 			 * Set the offset and limit for the returned results.
 			 */
 			if( isset($options['result_offset']) && isset($options['result_limit']) )
-				$this->sphinx->setLimits($options['result_offset'], $options['result_limit']);
+				$this->sphinx->setLimits($options['result_offset'], $options['result_limit'],5000);
 
 			/**
 			 * Weight the individual fields.
@@ -164,5 +164,52 @@ class Sphinxsearch
 		 * FIXME: Throw an exception if $results is empty?
 		 */
 		return $results;
+	}
+
+	/**
+	 * Reset all previously set filters.
+	 *
+	 */
+        public function resetFilters() {
+		$this->sphinx->resetFilters();
+	}
+
+	/**
+	 * Adds query with the current settings to multi-query batch. This method doesn't affect current settings (sorting, filtering, grouping etc.) in any way.
+	 * @param string $query The query string that we are searching for.
+	 * @param array $indexes The indexes to perform the search on.
+	 *
+         * $indexes = array(
+	 *   'IndexLabel',
+         *   'IndexLabel2'
+         *  );
+	 */
+        public function addQuery($search_str, $indexes) {
+		$indexnames = '';
+
+		//Create string on index names
+		foreach( $indexes as $label) {
+
+			/**
+			 * Ensure that the label corresponds to a defined index.
+			 */
+			if(isset($this->indexes[$label])){
+
+				/*
+				* Create string of index names for SphinxAPI query function.
+				*/
+				$indexnames .= $this->indexes[$label].' ';
+			} 
+		}
+
+		$this->sphinx->addQuery($search_str, $indexnames);
+	}
+
+       /**
+	* Connects to searchd, runs a batch of all queries added using SphinxClient::addQuery, obtains and returns the result sets.
+	*
+        */
+       public function runQueries() {
+		return $this->sphinx->runQueries();
 	}
 }

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -211,11 +211,27 @@ class Sphinxsearch
 		$this->sphinx->addQuery($search_str, $indexnames);
 	}
 
-       /**
+   /**
 	* Connects to searchd, runs a batch of all queries added using SphinxClient::addQuery, obtains and returns the result sets.
 	*
-        */
-       public function runQueries() {
+    */
+    public function runQueries() {
 		return $this->sphinx->runQueries();
 	}
+
+	/**
+	* Set sort mode for search.
+	* @param $mode Sortmode as specifed in Sphinx API Doc on of: 
+	*		SPH_SORT_RELEVANCE	Sort by relevance in descending order (best matches first).
+	*		SPH_SORT_ATTR_DESC	Sort by an attribute in descending order (bigger attribute values first).
+	*		SPH_SORT_ATTR_ASC	Sort by an attribute in ascending order (smaller attribute values first).
+	*		SPH_SORT_TIME_SEGMENTS	Sort by time segments (last hour/day/week/month) in descending order, and then by relevance in descending order.
+	*		SPH_SORT_EXTENDED	Sort by SQL-like combination of columns in ASC/DESC order.
+	*		SPH_SORT_EXPR
+	* @param $sortby String name of field to sort.
+	*/
+	public function setSortMode($mode, $sortby){
+		$this->sphinx->setSortMode($mode, $sortby);
+	}
 }
+

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -119,6 +119,7 @@ class Sphinxsearch
 		if( $escapeQuery )
 			$query = $this->sphinx->escapeString($query);
 
+		$indexnames = '';
 		$results = array();
 		foreach( $indexes as $label => $options ) {
 			/**
@@ -139,13 +140,19 @@ class Sphinxsearch
 			if( isset($options['field_weights']) )
 				$this->sphinx->setFieldWeights($options['field_weights']);
 
-			/**
-			 * Perform the query.
-			 */
-			$results[$label] = $this->sphinx->query($query, $this->indexes[$label]);
-			if( $results[$label]['status'] !== SEARCHD_OK )
-				throw new \RuntimeException(sprintf('Searching index "%s" for "%s" failed with error "%s".', $label, $query, $this->sphinx->getLastError()));
+			/*
+			* Create string of index names for query function.
+			*/
+			$indexnames .= $this->indexes[$label].' ';
 		}
+
+		/**
+		 * Perform the query.
+		 */
+		$results = $this->sphinx->query($query, $indexnames);
+
+		if( $results['status'] !== SEARCHD_OK )
+			throw new \RuntimeException(sprintf('Searching index "%s" for "%s" failed with error "%s".', $label, $query, $this->sphinx->getLastError()));
 
 		/**
 		 * If only one index was searched, return that index's results directly.

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -141,7 +141,7 @@ class Sphinxsearch
 				$this->sphinx->setFieldWeights($options['field_weights']);
 
 			/*
-			* Create string of index names for query function.
+			* Create string of index names for SphinxAPI query function.
 			*/
 			$indexnames .= $this->indexes[$label].' ';
 		}

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -134,7 +134,7 @@ class Sphinxsearch
 			 * Set the offset and limit for the returned results.
 			 */
 			if( isset($options['result_offset']) && isset($options['result_limit']) )
-				$this->sphinx->setLimits($options['result_offset'], $options['result_limit'],5000);
+				$this->sphinx->setLimits($options['result_offset'], $options['result_limit'],20000);
 
 			/**
 			 * Weight the individual fields.

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -121,7 +121,9 @@ class Sphinxsearch
 
 		$indexnames = '';
 		$results = array();
+		$i = 0;
 		foreach( $indexes as $label => $options ) {
+		
 			/**
 			 * Ensure that the label corresponds to a defined index.
 			 */
@@ -143,7 +145,11 @@ class Sphinxsearch
 			/*
 			* Create string of index names for SphinxAPI query function.
 			*/
-			$indexnames .= $this->indexes[$label].' ';
+			if($i == 1){
+				$indexnames .= ' ';
+			}
+			$indexnames .= $this->indexes[$label];
+			$i++;
 		}
 
 		/**

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -134,7 +134,7 @@ class Sphinxsearch
 			 * Set the offset and limit for the returned results.
 			 */
 			if( isset($options['result_offset']) && isset($options['result_limit']) )
-				$this->sphinx->setLimits($options['result_offset'], $options['result_limit'],20000);
+				$this->sphinx->setLimits($options['result_offset'], $options['result_limit'], 100000);
 
 			/**
 			 * Weight the individual fields.

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "search/sphinxsearch-bundle",
+  "name": "chrisapl/search-sphinxsearchbundle",
   "type": "symfony-bundle",
   "description": "Sphinx search bundle for Symfony 2",
   "keywords": ["sphinx", "sphinxsearch", "symfony2"],
-  "homepage": "https://github.com/timewasted/Search-SphinxsearchBundle",
+  "homepage": "https://github.com/chrisapl/Search-SphinxsearchBundle",
   "license": "BSD-2-Clause",
   "authors": [
     {


### PR DESCRIPTION
Sorry, had wrong commits attached to previous pull...

I have changed the search function to match the intended SphinxAPI behavior.

Previously when you searched multiple indexes with:
    $indexes = array(
       'All_Items' => array(
      'result_offset' => 0,
      'result_limit' => 1000
    ),
    'All_Items_Delta' => array(
      'result_offset' => 0,
      'result_limit' => 1000
   )
   );

$result = $sphinxsearch->search($search_str,$indexes);
It executed SphinxAPI->query() once for each index and saved the results to a named array. This means advanced functionality like kill-lists do not work.

I have changed it so it now executes SphinxAPI->query() once with both indexes and my kill-list now works as intended which means I can have a delta index of updates and a full index but, not have results from the full index returned if that document exists in delta index (the delta being the latest version).

If someone wanted to execute a search on two different indexes independently I would expect they run SphinxSearchBundle->search() twice.

Anyhow fix my problem, not sure if you want to include it in the bundle.

Additionally I changed the sphinxsearch.xml so that bundle worked when installed to vendors/bundles/Search/SphinxSearch/ which I think would be the conventional location for the 3rd party bundle in the Symfony2 framework.

Cheers for all your hard work, made it much easier for me to integrate Sphinx and Symfony2 thats for sure!
