### PR TITLE
Update sphinxsearch.xml

### DIFF
--- a/Resources/config/sphinxsearch.xml
+++ b/Resources/config/sphinxsearch.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="search.sphinxsearch.api.path">%kernel.root_dir%/../vendor/search/sphinxsearch-bundle/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</parameter>
         <parameter key="search.sphinxsearch.indexer.class">Search\SphinxsearchBundle\Services\Indexer\Indexer</parameter>
         <parameter key="search.sphinxsearch.search.class">Search\SphinxsearchBundle\Services\Search\Sphinxsearch</parameter>
     </parameters>
@@ -16,7 +17,7 @@
         </service>
 
         <service id="search.sphinxsearch.search" class="%search.sphinxsearch.search.class%">
-            <file>%kernel.root_dir%/../vendor/search/sphinxsearch-bundle/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
+            <file>%search.sphinxsearch.api.path%</file>
             <argument>%search.sphinxsearch.searchd.host%</argument>
             <argument>%search.sphinxsearch.searchd.port%</argument>
             <argument>%search.sphinxsearch.searchd.socket%</argument>


### PR DESCRIPTION
API path really should be changeable - it's pain in ass to mess with service definition when you use different version of Sphinx server (for example only available on Debian Squeeze is ancient 0.9.9).
