### PR TITLE
Require SphinxAPI.php by composer directive

### DIFF
--- a/Resources/config/sphinxsearch.xml
+++ b/Resources/config/sphinxsearch.xml
@@ -16,7 +16,6 @@
         </service>
 
         <service id="search.sphinxsearch.search" class="%search.sphinxsearch.search.class%">
-            <file>%kernel.root_dir%/../vendor/search/sphinxsearch-bundle/Search/SphinxsearchBundle/Services/Search/SphinxAPI.php</file>
             <argument>%search.sphinxsearch.searchd.host%</argument>
             <argument>%search.sphinxsearch.searchd.port%</argument>
             <argument>%search.sphinxsearch.searchd.socket%</argument>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
   "autoload": {
     "psr-0": {
       "Search\\SphinxsearchBundle": ""
-    }
+    },
+    "files": [
+      "Services/Search/SphinxAPI.php"
+    ]
   },
   "target-dir": "Search/SphinxsearchBundle"
 }


### PR DESCRIPTION
%kernel.root_dir%/../vendor does not work for multiple applications in a single installation framework
