### PR TITLE
Added option check to ignore warnings when searching

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,6 @@
 About SphinxsearchBundle
 ========================
 
-
-
 Installation:
 -------------
 
@@ -11,7 +9,19 @@ Installation:
 
 ### Step 1: Download the bundle
 
-How you actually download the bundle is entirely up to you.  The easiest way is to grab it from [packagist.org](http://packagist.org/).
+How you actually download the bundle is entirely up to you. Since I'm not sure how much time I'll be able to spend maintaining this bundle, I've opted to keep it as a VCS bundle for now and not put it on packagist. This may change in the future if there is enough interest. The relevant portions of composer.json are:
+
+``` JSON
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:spreston/Search-SphinxsearchBundle.git"
+        }
+    ],
+    "require": {
+        "search/sphinxsearch-bundle": "dev-master",
+    }
+```
 
 ### Step 2: Configure the bundle
 
@@ -30,7 +40,7 @@ sphinxsearch:
 
 At least one index must be defined, and you may define as many as you like.
 
-In the above sample configuration, `Categories` is used as a label for the index named `%sphinxsearch_index_categories%` (as defined in your `sphinxsearch.conf`).  This allows you to avoid having to hard code raw index names inside of your code.
+In the above sample configuration, `Categories` is used as a label for the index named `%sphinxsearch_index_categories%` (as defined in your `sphinxsearch.conf`).  This allows you to avoid having to hard code raw index names inside of your configuration.
 
 
 
@@ -74,7 +84,9 @@ License:
 --------
 
 ```
-Copyright (c) 2012, Ryan Rogers
+Copyright (c) 
+    2012, Ryan Rogers
+    2014, Steve Preston
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,7 @@ $indexesToSearch = array('Items');
 $options = array(
   'result_offset' => 0,
   'result_limit' => 25,
+  'ignore_warnings' => true, 
   'field_weights' => array(
     'Name' => 2,
     'SKU' => 3,
@@ -65,7 +66,7 @@ $sphinxSearch->setFilter('disabled', array(1), true);
 $searchResults = $sphinxSearch->search('search query', $indexesToSearch, $options);
 ```
 
-This would again search `Items` for `search query`, but now it will only return up to the first 25 matches and weight the `Name` and `SKU` fields higher than normal.  Note that in order to define a `result_offset` or a `result_limit`, you must explicitly define both values.  Also, this search will use [the Extended query syntax](http://sphinxsearch.com/docs/current.html#extended-syntax), and exclude all results with a `disabled` attribute set to 1.
+This would again search `Items` for `search query`, but now it will only return up to the first 25 matches and weight the `Name` and `SKU` fields higher than normal.  Note that in order to define a `result_offset` or a `result_limit`, you must explicitly define both values.  Also, this search will use [the Extended query syntax](http://sphinxsearch.com/docs/current.html#extended-syntax), and exclude all results with a `disabled` attribute set to 1. The ignore_warnings option is recommended if you plan on using the @@relaxed option, as it returns a warning when non-existent fields are referenced.
 
 
 

--- a/Services/Search/Sphinxsearch.php
+++ b/Services/Search/Sphinxsearch.php
@@ -176,7 +176,13 @@ class Sphinxsearch
 		 * Perform the query.
 		 */
 		$results = $this->sphinx->query($query, $indexNames);
-		if( $results['status'] !== SEARCHD_OK )
+
+        /**
+         * If status is not ok and status is not ignored warning
+         * This is required for '@@relaxed' to work correctly since it returns a warning on non-existent fields
+         */
+        if( $results['status'] !== SEARCHD_OK && 
+            !($results['status'] == SEARCHD_WARNING && isset($options['ignore_warnings']) && $options['ignore_warnings']) )
 			throw new \RuntimeException(sprintf('Searching index "%s" for "%s" failed with error "%s".', $label, $query, $this->sphinx->getLastError()));
 
 		return $results;

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-  "name": "search/sphinxsearch-bundle",
+  "name": "spreston/sphinxsearch-bundle",
   "type": "symfony-bundle",
-  "description": "Sphinx search bundle for Symfony 2",
+  "description": "Sphinx search bundle for Symfony 2. Forked from https://github.com/timewasted/Search-SphinxsearchBundle",
   "keywords": ["sphinx", "sphinxsearch", "symfony2"],
-  "homepage": "https://github.com/timewasted/Search-SphinxsearchBundle",
+  "homepage": "https://github.com/spreston/Search-SphinxsearchBundle",
   "license": "BSD-2-Clause",
   "authors": [
+    {
+      "name": "Steve Preston",
+      "email": "spreston@bcgtrans.com"
+    },
     {
       "name": "Ryan Rogers",
       "email": "ryan@timewasted.me"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "spreston/sphinxsearch-bundle",
+  "name": "search/sphinxsearch-bundle",
   "type": "symfony-bundle",
   "description": "Sphinx search bundle for Symfony 2. Forked from https://github.com/timewasted/Search-SphinxsearchBundle",
   "keywords": ["sphinx", "sphinxsearch", "symfony2"],


### PR DESCRIPTION
I needed to be able to ignore warnings, since @@relaxed returns a warning when a non-existent field is searched on an index. This is very helpful for a global search that searches multiple index with dissimilar schema.
